### PR TITLE
chore(ci): add path-based filtering to skip irrelevant CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'src/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'alembic/**'
+              - 'scripts/**'
+              - 'docker/**'
+              - 'docker-compose*.yml'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/ci.yml'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -49,8 +76,9 @@ jobs:
           fail_ci_if_error: false
 
   integration-test:
+    needs: [changes, test]
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
-    needs: test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -72,6 +100,8 @@ jobs:
         run: uv run pytest tests/integration/ -v --timeout=120
 
   frontend-test:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -100,8 +130,9 @@ jobs:
         run: npm run build --prefix frontend
 
   e2e-test:
+    needs: [changes, frontend-test]
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
-    needs: frontend-test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -136,6 +167,8 @@ jobs:
           retention-days: 7
 
   validate-guardrails:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ciso-assistant-security.yml
+++ b/.github/workflows/ciso-assistant-security.yml
@@ -3,10 +3,10 @@ name: CISO Assistant Security Check
 on:
   pull_request:
     paths:
-      - '**.py'
-      - '**.yaml'
-      - '**.yml'
-      - '**.md'
+      - 'src/**/*.py'
+      - 'scripts/security/**'
+      - 'pyproject.toml'
+      - 'docker/**'
       - '.github/workflows/ciso-assistant-security.yml'
 
 permissions:


### PR DESCRIPTION
## Summary

Add `dorny/paths-filter` change detection so docs-only or skills-only PRs skip all test/lint/build jobs — saving CI minutes and speeding up feedback. Motivated by PR #68 which changed only a skill markdown file yet triggered all 6 CI jobs.

### Changes

**`.github/workflows/ci.yml`**:
- New `changes` job using `dorny/paths-filter@v3` with `backend` and `frontend` filter groups
- `test`, `integration-test`, `validate-guardrails` gated on `backend == 'true'`
- `frontend-test`, `e2e-test` gated on `frontend == 'true'`
- CI workflow changes (`.github/workflows/ci.yml`) included in both filters as safety net

**`.github/workflows/ciso-assistant-security.yml`**:
- Narrowed trigger paths from `**.py / **.yaml / **.yml / **.md` to `src/**/*.py`, `scripts/security/**`, `pyproject.toml`, `docker/**`, and the workflow itself

### Skip matrix

| Changed files | Jobs that run |
|--------------|---------------|
| `.claude/**`, `docs/**`, `*.md` | Only `changes` (~5s) |
| `src/`, `tests/`, `pyproject.toml` | `test` → `integration-test`, `validate-guardrails` |
| `frontend/` | `frontend-test` → `e2e-test` |
| `.github/workflows/ci.yml` | All jobs |

## Test plan

- [x] YAML validated with Python `yaml.safe_load()`
- [x] Pre-commit hooks pass
- [ ] Verify this PR itself only runs `changes` job (no Python/frontend changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)